### PR TITLE
Simplify readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,12 @@ Jaeger can also be installed as `developer` (or any other user). As the DaemonSe
 however, your user need to have such permission. It can be achieved by running this:
 
 ```bash
+oc login -u developer
+oc new-project jaeger
+
 oc login -u system:admin
 oc create -f https://raw.githubusercontent.com/jaegertracing/jaeger-openshift/master/production/daemonset-admin.yml
-oadm policy add-role-to-user daemonset-admin developer -n jaeger // note that namespace jaeger has been already created
+oc adm policy add-role-to-user daemonset-admin developer -n jaeger // jaeger namespace has been already created and it is accessible by developer user
 ```
 
 Once that is ready, it's only a matter of creating the components from the template:

--- a/README.md
+++ b/README.md
@@ -1,137 +1,56 @@
 # Jaeger OpenShift Templates
 
 ## Development setup
-
 This template uses an in-memory storage with a limited functionality for local testing and development.
 Do not use this template in production environments.
 
-To directly install everything you need:
+Install everything in the current namespace:
 ```bash
-oc new-project jaeger-infra
 oc process -f https://raw.githubusercontent.com/jaegertracing/jaeger-openshift/master/all-in-one/jaeger-all-in-one-template.yml | oc create -f -
 ```
 
-Once everything is ready, the Jaeger Query UI can be accessed via http://jaeger-jaeger-infra.127.0.0.1.nip.io/ .
+Once everything is ready, `oc status` tells you where to find Jaeger URL.
 
 ## Production setup
+This template deploys all Jaeger components as a separate services: StatefulSet Cassandra storage, agent as DaemonSet,
+collector and query service with UI. Each one of those can be managed and scaled individually. Because this template
+deploys the agent as a DaemonSet it requires system:admin permissions, therefore cannot be used in OpenShift online.
 
-### TL;DR
-
-Install with:
-```bash
-oc login -u system:admin
-oc new-project jaeger-infra
-oc process -f https://raw.githubusercontent.com/jaegertracing/jaeger-openshift/master/production/jaeger-production-template.yml | oc create -f -
-oc policy add-role-to-user cluster-admin developer -n jaeger-infra
-```
-
-Once everything is ready, the Jaeger Query UI can be accessed via http://jaeger-jaeger-infra.127.0.0.1.nip.io/ .
-
-Your Agent hostname is `jaeger-agent.jaeger-infra.svc.cluster.local`
-
-Clean up with:
-```bash
-oc delete all,template,daemonset -l jaeger-infra
-```
-
-### Detailed instructions
-
-You may choose to deploy the Jaeger instance on its own namespace or on an existing namespace,
-with the installation done by an admin or by an unprivileged user. In any case, you'll need your
-Tracer to be pointed to the Agent, which is available at a hostname following this pattern:
-
-```
-jaeger-agent.${NAMESPACE}.svc.cluster.local
-```
-
-For instance, when deployed on its own namespace `jaeger-infra`, this is the full hostname:
-
-```
-jaeger-agent.jaeger-infra.svc.cluster.local
-```
-
-#### Creating the deployment
-
-The `jaeger-production-template.yml` file provides a quick start to deploy a production-ready instance of Jaeger on OpenShift.
-The template includes a `StatefulSet` for Cassandra, a `DaemonSet` for the Agent, a `Job` that creates the schema,
-as well as regular services for the individual components such as `Collector` and `Query`. Each one of those
-can be managed and scaled individually.
-
-#### Installing Jaeger on its own namespace as `admin`
-
-Ideally, the Jaeger components would run on its own namespace. For the recommended setup, these are the commands
-to be issued:
-
+Install everything in `jaeger` namespace:
 ```bash
 oc login -u system:admin
 oc new-project jaeger
-oc process -f jaeger-production-template.yml | oc create -f -
+oc process -f https://raw.githubusercontent.com/jaegertracing/jaeger-openshift/master/production/jaeger-production-template.yml | oc create -n jaeger -f -
 ```
 
-To be able to manage the objects via the UI, add the appropriate permissions to your user. For development
-purposes, this can be executed to get the `developer` user to access the Jaeger namespace as `cluster-admin`:
-
+Give user `developer` permissions to access `jaeger` namespace:
 ```bash
-oc login -u system:admin
 oc policy add-role-to-user cluster-admin developer -n jaeger
 ```
 
-#### Installing Jaeger under an existing namespace as `developer`
+Note that it's OK to have the Query and Collector pods to be in an error state for the first minute or so. This is
+because these components attempt to connect to Cassandra right away and hard fail if they can't after N attempts.
 
-Jaeger can also be installed as `developer` (or any other user). As the `DaemonSet` runs at the node level,
+Your Agent hostname is `jaeger-agent.${NAMESPACE}.svc.cluster.local`
+
+### Install Jaeger as `developer` user
+
+Jaeger can also be installed as `developer` (or any other user). As the DaemonSet runs at the node level,
 however, your user need to have such permission. It can be achieved by running this:
 
 ```bash
 oc login -u system:admin
 oc create -f daemonset-admin.yml
-oadm policy add-role-to-user daemonset-admin developer
+oadm policy add-role-to-user daemonset-admin developer -n jaeger // note that namespace jaeger has been already created
 ```
 
 Once that is ready, it's only a matter of creating the components from the template:
 ```bash
-oc process -f jaeger-production-template.yml -p NAMESPACE=myproject | oc create -f -
+oc login -u developer
+oc process -f jaeger-production-template.yml | oc create -n jaeger -f -
 ```
 
-#### Post install
-
-The Docker images should be pulled automatically from Docker Hub, and all other processes should also complete
-automatically. Once everything is ready, the Jaeger Query UI can be accessed via http://jaeger-jaeger-infra.127.0.0.1.nip.io/ .
-Don't forget to replace `127.0.0.1` by your OpenShift IP, shown as the result of `oc cluster up` or `oc status`.
-
-Note that it's OK to have the Query and Collector pods to be in an error state for the first minute or so. This is
-because these components attempt to connect to Cassandra right away and hard fail if they can't after N attempts.
-After a hard fail, OpenShift/Kubernetes will schedule a new pod. As Cassandra will eventually be ready, the pods
-will eventually work.
-
-This is how it looks like at different times:
-
-```bash
-$ oc get pods
-NAME                                READY     STATUS              RESTARTS   AGE
-cassandra-0                         1/1       Running             0          33s
-cassandra-1                         0/1       ContainerCreating   0          2s
-jaeger-agent-jgprc                  1/1       Running             0          33s
-jaeger-cassandra-schema-job-n1806   1/1       Running             0          33s
-jaeger-collector-1-deploy           1/1       Running             0          33s
-jaeger-collector-1-xqb7k            0/1       CrashLoopBackOff    1          28s
-jaeger-query-1-deploy               1/1       Running             0          33s
-jaeger-query-1-h089j                0/1       Error               2          28s
-jaeger-ui-1-97dk7                   1/1       Running             0          29s
-$ oc get pods
-NAME                                READY     STATUS      RESTARTS   AGE
-cassandra-0                         1/1       Running     0          1m
-cassandra-1                         0/1       Running     0          29s
-jaeger-agent-jgprc                  1/1       Running     0          1m
-jaeger-cassandra-schema-job-n1806   0/1       Completed   0          1m
-jaeger-collector-1-xqb7k            1/1       Running     2          55s
-jaeger-query-1-h089j                1/1       Running     3          55s
-```
-
-#### Where to go from here
-
-This template is meant to serve as a starting point for your own installation, or as a quick start tool
-for developers interested in having an OpenTracing backend for their microservices deployed on OpenShift.
-
+### Persistent storage
 Even though this template uses a stateful Cassandra, backing storage is set to `emptyDir`. It's more
 appropriate to create a `PersistentVolumeClaim`/`PersistentVolume` and use it instead.
 

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ however, your user need to have such permission. It can be achieved by running t
 
 ```bash
 oc login -u system:admin
-oc create -f daemonset-admin.yml
+oc create -f https://raw.githubusercontent.com/jaegertracing/jaeger-openshift/master/production/daemonset-admin.yml
 oadm policy add-role-to-user daemonset-admin developer -n jaeger // note that namespace jaeger has been already created
 ```
 
 Once that is ready, it's only a matter of creating the components from the template:
 ```bash
 oc login -u developer
-oc process -f jaeger-production-template.yml | oc create -n jaeger -f -
+oc process -f https://raw.githubusercontent.com/jaegertracing/jaeger-openshift/master/production/jaeger-production-template.yml | oc create -n jaeger -f -
 ```
 
 ### Persistent storage

--- a/all-in-one/jaeger-all-in-one-template.yml
+++ b/all-in-one/jaeger-all-in-one-template.yml
@@ -23,18 +23,12 @@ parameters:
   name: IMAGE_VERSION
   required: false
   value: 9f3984cd
-- description: The namespace where to install the Jaeger instance
-  displayName: Namespace
-  name: NAMESPACE
-  required: false
-  value: jaeger-infra
 
 apiVersion: v1
 kind: Template
 labels:
   template: jaeger-template-all-in-one
   jaeger-infra: template-all-in-one
-message: 'A Jaeger service has been created in your project.'
 metadata:
   name: jaeger-template-all-in-one
   annotations:
@@ -44,11 +38,11 @@ metadata:
     tags: instant-app,tracing,opentracing,jaeger
   labels:
     name: jaeger-infra
+    jaeger-infra: jaeger-template-all-in-one
 objects:
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
-    namespace: "${NAMESPACE}"
     name: ${JAEGER_SERVICE_NAME}
     labels:
       name: jaeger-dc
@@ -87,7 +81,6 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    namespace: "${NAMESPACE}"
     name: ${JAEGER_SERVICE_NAME}
     labels:
       name: jaeger-service
@@ -116,7 +109,6 @@ objects:
 - apiVersion: v1
   kind: Route
   metadata:
-    namespace: "${NAMESPACE}"
     name: ${JAEGER_SERVICE_NAME}-query
     labels:
       jaeger-infra: query-route

--- a/all-in-one/src/test/java/io/jaegertracing/openshift/AllInOneETest.java
+++ b/all-in-one/src/test/java/io/jaegertracing/openshift/AllInOneETest.java
@@ -34,7 +34,7 @@ import okhttp3.Response;
  */
 @RunWith(ArquillianConditionalRunner.class)
 public class AllInOneETest {
-    private static final String SERVICE_NAME = "jaeger-all-in-one";
+    private static final String SERVICE_NAME = "jaeger";
 
     private OkHttpClient okHttpClient = new OkHttpClient.Builder()
             .build();

--- a/production/jaeger-production-template.yml
+++ b/production/jaeger-production-template.yml
@@ -28,11 +28,6 @@ parameters:
   name: KEYSPACE
   required: true
   value: jaeger_v1_dc1
-- description: The namespace where to install the Jaeger instance
-  displayName: Namespace
-  name: NAMESPACE
-  required: false
-  value: jaeger-infra
 
 apiVersion: v1
 kind: Template
@@ -40,7 +35,6 @@ labels:
   app: jaeger
   template: jaeger-template
   jaeger-infra: template
-message: 'A Jaeger service has been created in your project.'
 metadata:
   name: jaeger-template
   annotations:
@@ -51,11 +45,11 @@ metadata:
   labels:
     app: jaeger
     name: jaeger-infra
+    jaeger-infra: template-production
 objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    namespace: "${NAMESPACE}"
     name: cassandra
     labels:
       app: jaeger
@@ -74,10 +68,9 @@ objects:
     clusterIP: None
     selector:
       app: cassandra
-- apiVersion: "apps/v1beta1"
+- apiVersion: apps/v1beta1
   kind: StatefulSet
   metadata:
-    namespace: "${NAMESPACE}"
     name: cassandra
     labels:
       app: jaeger
@@ -115,7 +108,7 @@ objects:
             - name: CASSANDRA_HOME
               value: "/opt/apache-cassandra-3.0.12"
             - name: CASSANDRA_CLUSTER_NAME
-              value: "jaeger"
+              value: jaeger
             - name: POD_IP
               valueFrom:
                 fieldRef:
@@ -125,7 +118,7 @@ objects:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CASSANDRA_SEED_POD
-              value: "cassandra-0.cassandra"
+              value: cassandra-0.cassandra
           readinessProbe:
             exec:
               command:
@@ -143,7 +136,6 @@ objects:
 - apiVersion: batch/v1
   kind: Job
   metadata:
-    namespace: "${NAMESPACE}"
     name: jaeger-cassandra-schema-job
     labels:
       app: jaeger
@@ -161,7 +153,6 @@ objects:
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
-    namespace: "${NAMESPACE}"
     name: ${JAEGER_SERVICE_NAME}-collector
     labels:
       app: jaeger
@@ -198,7 +189,6 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    namespace: "${NAMESPACE}"
     name: ${JAEGER_SERVICE_NAME}-collector
     labels:
       app: jaeger
@@ -215,7 +205,6 @@ objects:
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
-    namespace: "${NAMESPACE}"
     name: ${JAEGER_SERVICE_NAME}-query
     labels:
       app: jaeger
@@ -258,7 +247,6 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    namespace: "${NAMESPACE}"
     name: ${JAEGER_SERVICE_NAME}-query
     labels:
       app: jaeger
@@ -275,7 +263,6 @@ objects:
 - apiVersion: v1
   kind: Route
   metadata:
-    namespace: "${NAMESPACE}"
     name: ${JAEGER_SERVICE_NAME}-query
     labels:
       app: jaeger
@@ -290,7 +277,6 @@ objects:
 - apiVersion: extensions/v1beta1
   kind: DaemonSet
   metadata:
-    namespace: "${NAMESPACE}"
     name: ${JAEGER_SERVICE_NAME}-agent
     labels:
       app: jaeger
@@ -321,7 +307,6 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    namespace: "${NAMESPACE}"
     name: ${JAEGER_SERVICE_NAME}-agent
     labels:
       app: jaeger


### PR DESCRIPTION
Why has namespace been removed from templates?
* namespace can be easily configured with `-n foo` option or just set by `oc project foo`
* if one does `oc create -f template` and template contains namespace parameter in the UI it will be visible only under the project when issuing `oc create` (this sucks). In order to fix it `oc create` has to be run in `openshift` namespace accessible by system:admin.

resolves https://github.com/jaegertracing/jaeger-openshift/issues/9 #15 