### PR TITLE
WIP: end-to-end tests

### DIFF
--- a/all-in-one/pom.xml
+++ b/all-in-one/pom.xml
@@ -53,6 +53,18 @@
       <version>${version.com.squareup.okhttp3-okhttp}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.uber.jaeger</groupId>
+      <artifactId>jaeger-core</artifactId>
+      <version>0.19.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-api</artifactId>
+      <version>1.1.13.Final</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/all-in-one/src/test/java/io/jaegertracing/openshift/AllInOneETest.java
+++ b/all-in-one/src/test/java/io/jaegertracing/openshift/AllInOneETest.java
@@ -15,16 +15,36 @@ package io.jaegertracing.openshift;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
 import org.arquillian.cube.kubernetes.annotations.Named;
+import org.arquillian.cube.kubernetes.annotations.Port;
 import org.arquillian.cube.kubernetes.annotations.PortForward;
+import org.arquillian.cube.kubernetes.api.Session;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.uber.jaeger.Tracer;
+import com.uber.jaeger.metrics.Metrics;
+import com.uber.jaeger.metrics.NullStatsReporter;
+import com.uber.jaeger.metrics.StatsFactoryImpl;
+import com.uber.jaeger.reporters.RemoteReporter;
+import com.uber.jaeger.samplers.ProbabilisticSampler;
+import com.uber.jaeger.senders.Sender;
+import com.uber.jaeger.senders.UdpSender;
+
+import io.fabric8.kubernetes.api.model.v2_2.EndpointAddress;
+import io.fabric8.kubernetes.api.model.v2_2.EndpointSubset;
+import io.fabric8.kubernetes.api.model.v2_2.Endpoints;
+import io.fabric8.kubernetes.api.model.v2_2.Pod;
 import io.fabric8.kubernetes.api.model.v2_2.Service;
+import io.fabric8.kubernetes.clnt.v2_2.KubernetesClient;
+import io.opentracing.Span;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -34,12 +54,14 @@ import okhttp3.Response;
  */
 @RunWith(ArquillianConditionalRunner.class)
 public class AllInOneETest {
+    private static final String TRACER_SERVICE_NAME = "test-tracer";
     private static final String SERVICE_NAME = "jaeger";
 
     private OkHttpClient okHttpClient = new OkHttpClient.Builder()
             .build();
 
     @Named(SERVICE_NAME)
+    @PortForward
     @ArquillianResource
     private Service jaegerService;
 
@@ -47,6 +69,18 @@ public class AllInOneETest {
     @PortForward
     @ArquillianResource
     private URL jaegerUiUrl;
+
+    @Named(SERVICE_NAME)
+    @PortForward
+    @Port(name = "agent-compact")
+    @ArquillianResource
+    private URL agentCompactUrl;
+
+    @ArquillianResource
+    private KubernetesClient client;
+
+    @ArquillianResource
+    private Session session;
 
     @Test
     public void testUiResponds() throws IOException, InterruptedException {
@@ -57,6 +91,69 @@ public class AllInOneETest {
 
         try (Response response = okHttpClient.newCall(request).execute()) {
             Assert.assertEquals(200, response.code());
+        }
+    }
+
+    @Test
+    public void testSpanReported() throws InterruptedException, IOException {
+        Service service = client.services().inNamespace(session.getNamespace()).withName(SERVICE_NAME).get();
+
+        Pod randomPod = getRandomPod(client, SERVICE_NAME, session.getNamespace());
+
+//        Sender sender = new UdpSender(service.getSpec().getClusterIP(), 0, 0);
+//        Sender sender = new UdpSender(randomPod.getStatus().getPodIP(), 0, 0);
+        Sender sender = new UdpSender(agentCompactUrl.getHost(), agentCompactUrl.getPort(), 0);
+        Tracer tracer = new com.uber.jaeger.Tracer.Builder(TRACER_SERVICE_NAME,
+                new RemoteReporter(sender, 100, 50,
+                        new Metrics(new StatsFactoryImpl(new NullStatsReporter()))),
+                new ProbabilisticSampler(1.0))
+                .build();
+
+        for (int i = 0; i < 2; i++) {
+            Span span = tracer.buildSpan("span")
+                    .withTag("foo", "bar").start();
+            span.finish();
+        }
+
+        Thread.sleep(3000);
+        tracer.close();
+
+        Request request = new Request.Builder()
+                .url(jaegerUiUrl + "api/traces?service=" + TRACER_SERVICE_NAME)
+                .get()
+                .build();
+
+        try (Response response = okHttpClient.newCall(request).execute()) {
+            Assert.assertEquals(200, response.code());
+
+            String body = response.body().string();
+            System.out.println(body);
+            Assert.assertTrue(body.contains("foo"));
+            Assert.assertTrue(body.contains("bar"));
+        }
+
+    }
+
+    private static Pod getRandomPod(KubernetesClient client, String name, String namespace) {
+        Endpoints endpoints = client.endpoints().inNamespace(namespace).withName(name).get();
+        List<String> pods = new ArrayList<>();
+        if (endpoints != null) {
+            for (EndpointSubset subset : endpoints.getSubsets()) {
+                for (EndpointAddress address : subset.getAddresses()) {
+                    if (address.getTargetRef() != null && "Pod".equals(address.getTargetRef().getKind())) {
+                        String pod = address.getTargetRef().getName();
+                        if (pod != null && !pod.isEmpty()) {
+                            pods.add(pod);
+                        }
+                    }
+                }
+            }
+        }
+        if (pods.isEmpty()) {
+            return null;
+        } else {
+            String chosen = pods.get(new Random().nextInt(pods.size()));
+            return client.pods().inNamespace(namespace).withName(chosen).get();
         }
     }
 }

--- a/all-in-one/src/test/java/io/jaegertracing/openshift/Main.java
+++ b/all-in-one/src/test/java/io/jaegertracing/openshift/Main.java
@@ -1,0 +1,36 @@
+package io.jaegertracing.openshift;
+
+import com.uber.jaeger.Tracer;
+import com.uber.jaeger.metrics.Metrics;
+import com.uber.jaeger.metrics.NullStatsReporter;
+import com.uber.jaeger.metrics.StatsFactoryImpl;
+import com.uber.jaeger.reporters.RemoteReporter;
+import com.uber.jaeger.samplers.ProbabilisticSampler;
+import com.uber.jaeger.senders.Sender;
+import com.uber.jaeger.senders.UdpSender;
+
+import io.opentracing.Span;
+
+/**
+ * @author Pavol Loffay
+ */
+public class Main {
+
+    public static void main(String[] args) throws InterruptedException {
+        Sender sender = new UdpSender("localhost", 41663, 0);
+        Tracer tracer = new com.uber.jaeger.Tracer.Builder("kok",
+                new RemoteReporter(sender, 100, 50,
+                        new Metrics(new StatsFactoryImpl(new NullStatsReporter()))),
+                new ProbabilisticSampler(1.0))
+                .build();
+
+        for (int i = 0; i < 100; i++) {
+            Span span = tracer.buildSpan("span")
+                    .withTag("foo", "bar").start();
+            span.finish();
+        }
+        tracer.close();
+
+        Thread.sleep(1000);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <version.com.squareup.okhttp3-okhttp>3.8.0</version.com.squareup.okhttp3-okhttp>
     <version.junit>4.12</version.junit>
     <version.org.awaitility-awaitility>3.0.0</version.org.awaitility-awaitility>
-    <version.org.arquillian.cube>1.4.0</version.org.arquillian.cube>
+    <version.org.arquillian.cube>1.5.0</version.org.arquillian.cube>
     <version.org.jboss.arquillian>1.1.13.Final</version.org.jboss.arquillian>
 
     <!-- plugins -->


### PR DESCRIPTION
End to end test which send data to the agent and query it from query service.

It seems that arquillian-cube does not support port forwarding for UDP ports https://github.com/arquillian/arquillian-cube/issues/728. I am not able for use `kubectl port-forward` for this port either :/.

Possible workarounds:
1. create a proxy which will be deployed in OC and accept spans in jaeger.thrift over HTTP and forwards them to jaeger agent.
2. Create an app which will be deployed inside the cluster and will report span data. (arq-cube can load multiple resource files)
3. Use local openshift cluster (oc cluster up). On my local setup I'm able to ping pod's address which we can get via `KubernetesClient`.
4. Send data directly to collector, this is not ideal we won't test agent.