### PR TITLE
Add OpenShift Auth Proxy

### DIFF
--- a/production/jaeger-production-template.yml
+++ b/production/jaeger-production-template.yml
@@ -28,6 +28,16 @@ parameters:
   name: KEYSPACE
   required: true
   value: jaeger_v1_dc1
+- description: The location of the proxy image
+  name: IMAGE_PROXY
+  value: openshift/oauth-proxy:v1.0.0  
+- description: The namespace to instantiate jaeger under. Defaults to 'jaeger-infra'.
+  name: NAMESPACE
+  value: jaeger-infra
+- description: The session secret for the proxy
+  name: SESSION_SECRET
+  generate: expression
+  from: "[a-zA-Z0-9]{43}"
 
 apiVersion: v1
 kind: Template
@@ -37,6 +47,7 @@ labels:
   jaeger-infra: template
 metadata:
   name: jaeger-template
+  namespace: "${NAMESPACE}"
   annotations:
     description: Jaeger Distributed Tracing Server
     iconClass: icon-go-gopher
@@ -47,10 +58,36 @@ metadata:
     name: jaeger-infra
     jaeger-infra: template-production
 objects:
+# Authorize the ${JAEGER_SERVICE_NAME}-query service account to read data about the cluster
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: ${JAEGER_SERVICE_NAME}-query
+    namespace: "${NAMESPACE}"
+    annotations:
+      serviceaccounts.openshift.io/oauth-redirectreference.query: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"${JAEGER_SERVICE_NAME}-query"}}'
+- apiVersion: authorization.openshift.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: ${JAEGER_SERVICE_NAME}-query-cluster-reader
+  roleRef:
+    name: cluster-reader
+  subjects:
+  - kind: ServiceAccount
+    name: ${JAEGER_SERVICE_NAME}-query
+    namespace: "${NAMESPACE}"
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: ${JAEGER_SERVICE_NAME}-query-secrets
+    namespace: "${NAMESPACE}"
+  stringData:
+    session_secret: "${SESSION_SECRET}="
 - apiVersion: v1
   kind: Service
   metadata:
     name: cassandra
+    namespace: "${NAMESPACE}"
     labels:
       app: jaeger
       name: jaeger-cassandra-service
@@ -74,6 +111,7 @@ objects:
   kind: StatefulSet
   metadata:
     name: cassandra
+    namespace: "${NAMESPACE}"
     labels:
       app: jaeger
       jaeger-infra: cassandra-statefulset
@@ -141,6 +179,7 @@ objects:
   kind: Job
   metadata:
     name: jaeger-cassandra-schema-job
+    namespace: "${NAMESPACE}"
     labels:
       app: jaeger
       jaeger-infra: cassandra-schema-job
@@ -163,6 +202,7 @@ objects:
   kind: Deployment
   metadata:
     name: ${JAEGER_SERVICE_NAME}-collector
+    namespace: "${NAMESPACE}"
     labels:
       app: jaeger
       jaeger-infra: collector-deployment
@@ -194,6 +234,7 @@ objects:
   kind: Service
   metadata:
     name: ${JAEGER_SERVICE_NAME}-collector
+    namespace: "${NAMESPACE}"
     labels:
       app: jaeger
       jaeger-infra: collector-service
@@ -214,6 +255,7 @@ objects:
   kind: Deployment
   metadata:
     name: ${JAEGER_SERVICE_NAME}-query
+    namespace: "${NAMESPACE}"
     labels:
       app: jaeger
       jaeger-infra: query-deployment
@@ -227,7 +269,33 @@ objects:
           app: jaeger
           jaeger-infra: query-pod
       spec:
+        serviceAccountName: ${JAEGER_SERVICE_NAME}-query
         containers:
+        # Deploy Jaeger behind an oauth proxy
+        - name: jaeger-query-proxy
+          image: ${IMAGE_PROXY}
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 8443
+            name: web
+          args:
+          - -provider=openshift
+          - -https-address=:8443
+          - -email-domain=*
+          - -upstream=http://localhost:16686
+          - -client-id=system:serviceaccount:${NAMESPACE}:${JAEGER_SERVICE_NAME}-query
+          - '-openshift-sar={"resource": "namespaces", "verb": "get", "resourceName": "${NAMESPACE}", "namespace": "${NAMESPACE}"}'
+          - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get", "resourceName": "${NAMESPACE}", "namespace": "${NAMESPACE}"}}'
+          - -tls-cert=/etc/tls/private/tls.crt
+          - -tls-key=/etc/tls/private/tls.key
+          - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+          - -cookie-secret-file=/etc/proxy/secrets/session_secret
+          - -skip-auth-regex=^/metrics
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: ${JAEGER_SERVICE_NAME}-query-tls
+          - mountPath: /etc/proxy/secrets
+            name: ${JAEGER_SERVICE_NAME}-query-secrets
         - image: jaegertracing/jaeger-query:${IMAGE_VERSION}
           name: ${JAEGER_SERVICE_NAME}-query
           ports:
@@ -245,19 +313,29 @@ objects:
             initialDelaySeconds: 5
         dnsPolicy: ClusterFirst
         restartPolicy: Always
+        volumes:
+        - name: ${JAEGER_SERVICE_NAME}-query-secrets
+          secret:
+            secretName: ${JAEGER_SERVICE_NAME}-query-secrets
+        - name: ${JAEGER_SERVICE_NAME}-query-tls
+          secret:
+            secretName: ${JAEGER_SERVICE_NAME}-query-tls
 - apiVersion: v1
   kind: Service
   metadata:
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: ${JAEGER_SERVICE_NAME}-query-tls
     name: ${JAEGER_SERVICE_NAME}-query
+    namespace: "${NAMESPACE}"
     labels:
       app: jaeger
       jaeger-infra: query-service
   spec:
     ports:
     - name: jaeger-query
-      port: 80
+      port: 443
       protocol: TCP
-      targetPort: 16686
+      targetPort: 8443
     selector:
       jaeger-infra: query-pod
     type: LoadBalancer
@@ -265,13 +343,14 @@ objects:
   kind: Route
   metadata:
     name: ${JAEGER_SERVICE_NAME}-query
+    namespace: "${NAMESPACE}"
     labels:
       app: jaeger
       jaeger-infra: query-route
   spec:
     tls:
-      insecureEdgeTerminationPolicy: Allow
-      termination: edge
+      insecureEdgeTerminationPolicy: Redirect
+      termination: Reencrypt
     to:
       kind: Service
       name: ${JAEGER_SERVICE_NAME}-query


### PR DESCRIPTION
Current production template exposes the query interface to the world. This locks it down and uses OpenShift for OAuth.
Based on https://github.com/openshift/origin/blob/master/examples/prometheus/prometheus.yaml