### PR TITLE
Remove executable as an argument to containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ For instance, assuming that your application is named `myapp` and the image is f
           - containerPort: 6832
             protocol: UDP
           command:
-          - "/go/bin/agent-linux"
           - "--collector.host-port=jaeger-collector.jaeger-infra.svc:14267"
 ```
 

--- a/jenkins-ci/jaeger-agent-template.yml
+++ b/jenkins-ci/jaeger-agent-template.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2018 The Jaeger Authors
+# Copyright 2017 The Jaeger Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -84,6 +84,7 @@ objects:
           image: jaegertracing/jaeger-agent:${IMAGE_VERSION}
           imagePullPolicy: Always
           command:
+          - "/go/bin/agent-linux"
           - "--collector.host-port=jaeger-collector:14267"
           ports:
           - containerPort: 5775

--- a/jenkins-ci/jaeger-agent-template.yml
+++ b/jenkins-ci/jaeger-agent-template.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 The Jaeger Authors
+# Copyright 2017-2018 The Jaeger Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -84,7 +84,6 @@ objects:
           image: jaegertracing/jaeger-agent:${IMAGE_VERSION}
           imagePullPolicy: Always
           command:
-          - "/go/bin/agent-linux"
           - "--collector.host-port=jaeger-collector:14267"
           ports:
           - containerPort: 5775

--- a/production/cassandra.yml
+++ b/production/cassandra.yml
@@ -120,7 +120,7 @@ items:
       spec:
         containers:
         - name: jaeger-cassandra-schema
-          image: jaegertracing/jaeger-cassandra-schema:1.2
+          image: jaegertracing/jaeger-cassandra-schema:1.6
           env:
             - name: MODE
               value: "prod"

--- a/production/configmap-cassandra.yml
+++ b/production/configmap-cassandra.yml
@@ -32,5 +32,3 @@ data:
     cassandra:
       servers: cassandra
       keyspace: jaeger_v1_dc1
-    query:
-      static-files: /go/jaeger-ui/

--- a/production/configmap-elasticsearch.yml
+++ b/production/configmap-elasticsearch.yml
@@ -30,5 +30,3 @@ data:
   query: |
     es:
       server-urls: http://elasticsearch:9200
-    query:
-      static-files: /go/jaeger-ui/

--- a/production/jaeger-production-template.yml
+++ b/production/jaeger-production-template.yml
@@ -67,8 +67,7 @@ objects:
         containers:
         - image: jaegertracing/jaeger-collector:${IMAGE_VERSION}
           name: ${JAEGER_SERVICE_NAME}-collector
-          command:
-            - "--config-file=/conf/collector.yaml"
+          args: ["--config-file=/conf/collector.yaml"]
           ports:
           - containerPort: 14267
             protocol: TCP
@@ -152,8 +151,7 @@ objects:
         containers:
         - image: jaegertracing/jaeger-query:${IMAGE_VERSION}
           name: jaeger-query
-          command:
-            - "--config-file=/conf/query.yaml"
+          args: ["--config-file=/conf/query.yaml"]
           ports:
           - containerPort: 16686
             protocol: TCP

--- a/production/jaeger-production-template.yml
+++ b/production/jaeger-production-template.yml
@@ -68,7 +68,6 @@ objects:
         - image: jaegertracing/jaeger-collector:${IMAGE_VERSION}
           name: ${JAEGER_SERVICE_NAME}-collector
           command:
-            - "/go/bin/collector-linux"
             - "--config-file=/conf/collector.yaml"
           ports:
           - containerPort: 14267
@@ -154,7 +153,6 @@ objects:
         - image: jaegertracing/jaeger-query:${IMAGE_VERSION}
           name: jaeger-query
           command:
-            - "/go/bin/query-linux"
             - "--config-file=/conf/query.yaml"
           ports:
           - containerPort: 16686

--- a/production/jaeger-production-template.yml
+++ b/production/jaeger-production-template.yml
@@ -22,7 +22,7 @@ parameters:
   displayName: Image version
   name: IMAGE_VERSION
   required: false
-  value: "1.2"
+  value: "1.6"
 - description: The name of the Jaeger Zipkin Service.
   displayName: Jaeger Zipkin Service Name
   name: JAEGER_ZIPKIN_SERVICE_NAME


### PR DESCRIPTION
Jaeger containers were changed to no longer require the path
to the executable as an argument to docker run, so remove all
instances of executable path

Signed-off-by: Zachary DiCesare zachary.v.dicesare@gmail.com