### PR TITLE
Add readinessProbe

### DIFF
--- a/all-in-one/jaeger-all-in-one-template.yml
+++ b/all-in-one/jaeger-all-in-one-template.yml
@@ -84,7 +84,7 @@ objects:
               readinessProbe:
                 httpGet:
                   path: "/"
-                  port: 16686
+                  port: 14269
                 initialDelaySeconds: 5
 - apiVersion: v1
   kind: Service

--- a/production/jaeger-production-template.yml
+++ b/production/jaeger-production-template.yml
@@ -75,6 +75,10 @@ objects:
             protocol: TCP
           - containerPort: 9411
             protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: 14269
           volumeMounts:
           - name: jaeger-configuration-volume
             mountPath: /conf
@@ -158,7 +162,7 @@ objects:
           readinessProbe:
             httpGet:
               path: "/"
-              port: 16686
+              port: 16687
           volumeMounts:
           - name: jaeger-configuration-volume
             mountPath: /conf


### PR DESCRIPTION
Signed-off-by: Eundoo Song <eundoo.song@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Jaeger should use health check port for readinessProbe 
- Resolves: https://github.com/jaegertracing/jaeger-kubernetes/issues/86

## Short description of the changes
- Same as https://github.com/jaegertracing/jaeger-kubernetes/pull/98
