### PR TITLE
Add max traces and compute resource parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Development setup
 This template uses an in-memory storage with a limited functionality for local testing and development.
-Do not use this template in production environments.
+Do not use this template in production environments, although there are a number of parameters in the
+template to constrain the maximum number of traces and the amount of CPU/Memory consumed to prevent
+node instability.
 
 Install everything in the current namespace:
 ```bash
@@ -14,7 +16,7 @@ Once everything is ready, `oc status` tells you where to find Jaeger URL.
 ## Production setup
 
 ### Backing storage
-The Jaeger Collector and Query require a backing storage to exist before being started up. As a starting point for your own 
+The Jaeger Collector and Query require a backing storage to exist before being started up. As a starting point for your own
 templates, we provide a basic template to deploy Cassandra. It is not ready for production and should be adapted before any
 real usage.
 
@@ -113,7 +115,7 @@ Cassandra deployment does not support deleting pods or scaling down, as this mig
 administrative tasks that are dependent on the final deployment architecture.
 
 ## Exposing Jaeger-Collector outside of Cluster
-Collector is by default accessible only to services running inside the cluster. 
+Collector is by default accessible only to services running inside the cluster.
 The easiest approach to expose the collector outside of the cluster is via the `jaeger-collector-http`
 HTTP port using an OpenShift Route:
 
@@ -125,8 +127,8 @@ This allows clients to send data directly to Collector via HTTP senders. If you 
 [ExternalIP or NodePort](https://docs.openshift.com/container-platform/3.3/dev_guide/getting_traffic_into_cluster.html)
 to expose the Collector service.
 
-Note that doing so will open the collector to be used by any external party, who will then 
-be able to create arbitrary spans. 
+Note that doing so will open the collector to be used by any external party, who will then
+be able to create arbitrary spans.
 It's advisable to put an OAuth Security Proxy in front of the collector and expose this proxy instead.
 
 ## Using a different version
@@ -157,7 +159,7 @@ oc create -n openshift -f https://raw.githubusercontent.com/jaegertracing/jaeger
 oc create -n openshift -f https://raw.githubusercontent.com/jaegertracing/jaeger-openshift/master/production/jaeger-production-template.yml
 ```
 
-Before provisioning a production instance, however, your users will need to provision a backing storage and install an appropriate `ConfigMap`, 
+Before provisioning a production instance, however, your users will need to provision a backing storage and install an appropriate `ConfigMap`,
 as described previously in this document.
 
 ## Uninstalling

--- a/all-in-one/jaeger-all-in-one-template.yml
+++ b/all-in-one/jaeger-all-in-one-template.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2018 The Jaeger Authors
+# Copyright 2017-2019 The Jaeger Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/all-in-one/jaeger-all-in-one-template.yml
+++ b/all-in-one/jaeger-all-in-one-template.yml
@@ -32,7 +32,7 @@ parameters:
   displayName: Max Traces
   name: MAX_TRACES
   required: true
-  value: "1000"
+  value: "50000"
 # See https://docs.okd.io/latest/dev_guide/compute_resources.html for the CPU/Memory Request/Limit parameters below
 - description: CPU request represents a minimum amount of CPU that your container may consume, but if there is no contention for CPU, it can use all available CPU on the node.
   displayName: CPU Request

--- a/all-in-one/jaeger-all-in-one-template.yml
+++ b/all-in-one/jaeger-all-in-one-template.yml
@@ -28,6 +28,32 @@ parameters:
   name: JAEGER_ZIPKIN_SERVICE_NAME
   required: true
   value: zipkin
+- description: Limit the number of traces stored in-memory, see https://www.jaegertracing.io/docs/latest/deployment/#memory
+  displayName: Max Traces
+  name: MAX_TRACES
+  required: true
+  value: "1000"
+# See https://docs.okd.io/latest/dev_guide/compute_resources.html for the CPU/Memory Request/Limit parameters below
+- description: CPU request represents a minimum amount of CPU that your container may consume, but if there is no contention for CPU, it can use all available CPU on the node.
+  displayName: CPU Request
+  name: CPU_REQUEST
+  required: true
+  value: "100m"
+- description: CPU limits control the maximum amount of CPU that your container may use independent of contention on the node.
+  displayName: CPU Limit
+  name: CPU_LIMIT
+  required: true
+  value: "500m"
+- description: In order to improve placement of pods in the cluster, specify the amount of memory required for a container to run.
+  displayName: Memory Request
+  name: MEMORY_REQUEST
+  required: true
+  value: "100Mi"
+- description: Constrain the amount of memory the container can use.
+  displayName: Memory Limit
+  name: MEMORY_LIMIT
+  required: true
+  value: "2Gi"
 
 apiVersion: v1
 kind: Template
@@ -71,6 +97,7 @@ objects:
                 value: "9411"
               image: jaegertracing/all-in-one:${IMAGE_VERSION}
               name: ${JAEGER_SERVICE_NAME}
+              args: ["--memory.max-traces=${MAX_TRACES}"]
               ports:
                 - containerPort: 5775
                   protocol: UDP
@@ -89,6 +116,13 @@ objects:
                   path: "/"
                   port: 14269
                 initialDelaySeconds: 5
+              resources:
+                requests:
+                  cpu: ${CPU_REQUEST}
+                  memory: ${MEMORY_REQUEST}
+                limits:
+                  cpu: ${CPU_LIMIT}
+                  memory: ${MEMORY_LIMIT}
 - apiVersion: v1
   kind: Service
   metadata:


### PR DESCRIPTION
Add parameters in the template to constrain the maximum number of
traces and the amount of CPU/Memory consumed. This provides guardrails
to prevent over-utilization of CPU/Memory on a node which is known to
cause instability. Even in a non-production environment, such
guardrails are critical.

Signed-off-by: Everett Toews <everett.toews@gmail.com>

## Which problem is this PR solving?

Resolves #101 

## Short description of the changes

As per the PR description above.